### PR TITLE
Update errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea/

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::string::FromUtf8Error;
 #[derive(thiserror::Error, Debug)]
 pub enum HelmError {
     #[error(
-    r#"Unable to find 'helm' executable
+        r#"Unable to find 'helm' executable
   Please make sure helm is installed and in your PATH.
   See https://helm.sh/docs/intro/install/ for more help"#
     )]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,20 @@
+use std::io::Error as IoError;
+use std::string::FromUtf8Error;
+
+#[derive(thiserror::Error, Debug)]
+pub enum HelmError {
+    #[error(
+    r#"Unable to find 'helm' executable
+  Please make sure helm is installed and in your PATH.
+  See https://helm.sh/docs/intro/install/ for more help"#
+    )]
+    HelmNotInstalled(IoError),
+    #[error("Failed to read helm client version: {0}")]
+    HelmVersionNotFound(String),
+    #[error("Failed to connect to Kubernetes")]
+    FailedToConnect,
+    #[error("Failed to parse helm output as UTF8")]
+    Utf8Error(#[from] FromUtf8Error),
+    #[error("Failed to parse JSON from helm output")]
+    Serde(#[from] serde_json::Error),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,36 +1,11 @@
-use std::io::Error as IoError;
 use std::process::{Command, Stdio};
-use std::string::FromUtf8Error;
-
-use flv_util::cmd::CommandExt;
 use serde::Deserialize;
-use thiserror::Error;
 use tracing::{instrument, warn};
 
-#[derive(Error, Debug)]
-pub enum HelmError {
-    #[error(
-        r#"Unable to find 'helm' executable
-  Please make sure helm is installed and in your PATH.
-  See https://helm.sh/docs/intro/install/ for more help"#
-    )]
-    HelmNotInstalled {
-        #[from]
-        source: IoError,
-    },
-    #[error("failed to read helm client version: {0}")]
-    HelmVersionNotFound(String),
-    #[error("failed to parse helm output as UTF8")]
-    Utf8Error {
-        #[from]
-        source: FromUtf8Error,
-    },
-    #[error("failed to parse JSON from helm output")]
-    Serde {
-        #[from]
-        source: serde_json::Error,
-    },
-}
+mod error;
+
+use flv_util::cmd::CommandExt;
+pub use crate::error::HelmError;
 
 /// Client to manage helm operations
 #[derive(Debug)]
@@ -46,11 +21,11 @@ impl HelmClient {
             .arg("version")
             .print()
             .output()
-            .map_err(|source| HelmError::HelmNotInstalled { source })?;
+            .map_err(HelmError::HelmNotInstalled)?;
 
         // Convert command output into a string
         let out_str =
-            String::from_utf8(output.stdout).map_err(|source| HelmError::Utf8Error { source })?;
+            String::from_utf8(output.stdout).map_err(HelmError::Utf8Error)?;
 
         // Check that the version command gives a version.
         // In the future, we can parse the version string and check
@@ -132,27 +107,36 @@ impl HelmClient {
     /// Searches the repo for the named helm chart
     #[instrument(skip(self))]
     pub fn search_repo(&self, chart: &str, version: &str) -> Result<Vec<Chart>, HelmError> {
-        let output = Command::new("helm")
+        let mut command = Command::new("helm");
+        command
             .args(&["search", "repo", chart])
             .args(&["--version", version])
-            .args(&["--output", "json"])
-            .print()
-            .output()?;
+            .args(&["--output", "json"]);
 
-        serde_json::from_slice(&output.stdout).map_err(|source| HelmError::Serde { source })
+        let output = command
+            .print()
+            .output()
+            .map_err(HelmError::HelmNotInstalled)?;
+
+        check_helm_stderr(output.stderr)?;
+        serde_json::from_slice(&output.stdout).map_err(HelmError::Serde)
     }
 
     /// Get all the available versions
     #[instrument(skip(self))]
     pub fn versions(&self, chart: &str) -> Result<Vec<Chart>, HelmError> {
-        let output = Command::new("helm")
+        let mut command = Command::new("helm");
+        command
             .args(&["search", "repo"])
             .args(&["--versions", chart])
-            .args(&["--output", "json", "--devel"])
+            .args(&["--output", "json", "--devel"]);
+        let output = command
             .print()
-            .output()?;
+            .output()
+            .map_err(HelmError::HelmNotInstalled)?;
 
-        serde_json::from_slice(&output.stdout).map_err(|source| HelmError::Serde { source })
+        check_helm_stderr(output.stderr)?;
+        serde_json::from_slice(&output.stdout).map_err(HelmError::Serde)
     }
 
     /// Checks that a given version of a given chart exists in the repo.
@@ -173,16 +157,20 @@ impl HelmClient {
         name: &str,
     ) -> Result<Vec<InstalledChart>, HelmError> {
         let exact_match = format!("^{}$", name);
-        let output = Command::new("helm")
+        let mut command = Command::new("helm");
+        command
             .arg("list")
             .arg("--filter")
             .arg(exact_match)
             .arg("--output")
-            .arg("json")
+            .arg("json");
+        let output = command
             .print()
-            .output()?;
+            .output()
+            .map_err(HelmError::HelmNotInstalled)?;
 
-        serde_json::from_slice(&output.stdout).map_err(|source| HelmError::Serde { source })
+        check_helm_stderr(output.stderr)?;
+        serde_json::from_slice(&output.stdout).map_err(HelmError::Serde)
     }
 
     /// get helm package version
@@ -192,11 +180,25 @@ impl HelmClient {
             .arg("version")
             .arg("--short")
             .output()
-            .map_err(|source| HelmError::HelmNotInstalled { source })?;
+            .map_err(HelmError::HelmNotInstalled)?;
         let version_text = String::from_utf8(helm_version.stdout)
-            .map_err(|source| HelmError::Utf8Error { source })?;
+            .map_err(HelmError::Utf8Error)?;
         Ok(version_text[1..].trim().to_string())
     }
+}
+
+/// Check for errors in Helm's stderr output
+///
+/// Returns `Ok(())` if everything is fine, or `HelmError` if something is wrong
+fn check_helm_stderr(stderr: Vec<u8>) -> Result<(), HelmError> {
+    if !stderr.is_empty() {
+        let stderr = String::from_utf8(stderr)?;
+        if stderr.contains("Kubernetes cluster unreachable") {
+            return Err(HelmError::FailedToConnect);
+        }
+    }
+
+    Ok(())
 }
 
 /// A representation of a chart definition in a repo.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-use std::process::{Command, Stdio};
 use serde::Deserialize;
+use std::process::{Command, Stdio};
 use tracing::{instrument, warn};
 
 mod error;
 
-use flv_util::cmd::CommandExt;
 pub use crate::error::HelmError;
+use flv_util::cmd::CommandExt;
 
 /// Client to manage helm operations
 #[derive(Debug)]
@@ -24,8 +24,7 @@ impl HelmClient {
             .map_err(HelmError::HelmNotInstalled)?;
 
         // Convert command output into a string
-        let out_str =
-            String::from_utf8(output.stdout).map_err(HelmError::Utf8Error)?;
+        let out_str = String::from_utf8(output.stdout).map_err(HelmError::Utf8Error)?;
 
         // Check that the version command gives a version.
         // In the future, we can parse the version string and check
@@ -181,8 +180,7 @@ impl HelmClient {
             .arg("--short")
             .output()
             .map_err(HelmError::HelmNotInstalled)?;
-        let version_text = String::from_utf8(helm_version.stdout)
-            .map_err(HelmError::Utf8Error)?;
+        let version_text = String::from_utf8(helm_version.stdout).map_err(HelmError::Utf8Error)?;
         Ok(version_text[1..].trim().to_string())
     }
 }


### PR DESCRIPTION
This pulls the error enum into its own file, `error.rs`, and adds detection for when helm fails to connect to Kubernetes. This is needed for friendly CLI error messages.