### PR TITLE
Switch from flv_util::cmd to fluvio_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "fluvio-command"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2dcf39df27ca6854ecf6adaf0e5cf83eafd668d27c1efc891ecc3a0b8a1f097"
 dependencies = [
  "once_cell",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,28 +2,27 @@
 # It is not intended for manual editing.
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "fluvio-helm"
-version = "0.4.0"
+name = "fluvio-command"
+version = "0.1.0"
 dependencies = [
- "flv-util",
- "serde",
- "serde_json",
+ "once_cell",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
-name = "flv-util"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de89447c8b4aecfa4c0614d1a7be1c6ab4a0266b59bb2713fd746901f28d124e"
+name = "fluvio-helm"
+version = "0.4.0"
 dependencies = [
- "log",
+ "fluvio-command",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tracing",
 ]
 
@@ -40,19 +39,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "log"
-version = "0.4.11"
+name = "once_cell"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if",
-]
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "proc-macro2"
@@ -122,18 +118,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -142,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-helm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fluvio-command",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,13 @@ authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio-helm"
 description = "Helm wrapper"
 
-
 [lib]
 name = "fluvio_helm"
 path = "src/lib.rs"
-
-
 
 [dependencies]
 tracing = "0.1.19"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.20"
-
-flv-util = "0.5.2"
+fluvio-command = { path = "../fluvio/src/command" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-helm"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ tracing = "0.1.19"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.20"
-fluvio-command = { path = "../fluvio/src/command" }
+fluvio-command = "0.1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use std::io::Error as IoError;
 use std::string::FromUtf8Error;
+use fluvio_command::CommandError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum HelmError {
@@ -17,4 +18,6 @@ pub enum HelmError {
     Utf8Error(#[from] FromUtf8Error),
     #[error("Failed to parse JSON from helm output")]
     Serde(#[from] serde_json::Error),
+    #[error("Failed to execute a command")]
+    Command(#[from] CommandError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
+use fluvio_command::CommandError;
 use std::io::Error as IoError;
 use std::string::FromUtf8Error;
-use fluvio_command::CommandError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum HelmError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-use std::{
-    path::PathBuf,
-    process::{Command, Stdio},
-};
+use std::path::PathBuf;
+use std::process::Command;
 
 use serde::Deserialize;
 use tracing::{instrument, warn};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,9 +220,7 @@ impl HelmClient {
     ///
     /// This only succeeds if the helm command can be found.
     pub fn new() -> Result<Self, HelmError> {
-        let output = Command::new("helm")
-            .arg("version")
-            .result()?;
+        let output = Command::new("helm").arg("version").result()?;
 
         // Convert command output into a string
         let out_str = String::from_utf8(output.stdout).map_err(HelmError::Utf8Error)?;
@@ -243,9 +241,7 @@ impl HelmClient {
     #[instrument(skip(self))]
     pub fn install(&self, args: &InstallArg) -> Result<(), HelmError> {
         let mut command = args.install();
-        command
-            .inherit()
-            .result()?;
+        command.result()?;
         Ok(())
     }
 
@@ -253,9 +249,7 @@ impl HelmClient {
     #[instrument(skip(self))]
     pub fn upgrade(&self, args: &InstallArg) -> Result<(), HelmError> {
         let mut command = args.upgrade();
-        command
-            .inherit()
-            .result()?;
+        command.result()?;
         Ok(())
     }
 
@@ -270,8 +264,7 @@ impl HelmClient {
             }
         }
         let mut command: Command = uninstall.into();
-
-        command.inherit();
+        command.result()?;
         Ok(())
     }
 
@@ -280,9 +273,6 @@ impl HelmClient {
     pub fn repo_add(&self, chart: &str, location: &str) -> Result<(), HelmError> {
         Command::new("helm")
             .args(&["repo", "add", chart, location])
-            .stdout(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .inherit()
             .result()?;
         Ok(())
     }
@@ -290,7 +280,7 @@ impl HelmClient {
     /// Updates the local helm repository
     #[instrument(skip(self))]
     pub fn repo_update(&self) -> Result<(), HelmError> {
-        Command::new("helm").args(&["repo", "update"]).inherit().result()?;
+        Command::new("helm").args(&["repo", "update"]).result()?;
         Ok(())
     }
 


### PR DESCRIPTION
This uses the new-and-improved `CommandExt` from fluvio_command. Right now this is using a path dependency, and should not be merged until the `fluvio-command` crate is published on crates.io