### PR TITLE
Bump fluivo-command dep to 0.2.0 for improved command errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "fluvio-command"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dcf39df27ca6854ecf6adaf0e5cf83eafd668d27c1efc891ecc3a0b8a1f097"
+checksum = "3b587d6cc4c0901a6766e133c64f727fc976c0a8bfa4518b22dfc7abed676b38"
 dependencies = [
  "once_cell",
  "thiserror",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-helm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "fluvio-command",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-helm"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -16,4 +16,4 @@ tracing = "0.1.19"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.20"
-fluvio-command = "0.1.0"
+fluvio-command = "0.2.0"


### PR DESCRIPTION
This is just a quick version bump, but will help us get better diagnostics when things go wrong in `fluvio-cluster`. Once we merge this we'll need to publish the new version.