### PR TITLE
Return additional attributes in InstalledChart

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,13 +399,13 @@ pub struct InstalledChart {
     /// The version of the app this chart installed
     pub app_version: String,
     /// The chart revision
-    revision: String,
+    pub revision: String,
     /// Date/time when the chart was last updated
-    updated: String,
+    pub updated: String,
     /// Status of the installed chart
-    status: String,
+    pub status: String,
     /// The ID of the chart that is installed
-    chart: String,
+    pub chart: String,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,7 +398,7 @@ pub struct InstalledChart {
     pub name: String,
     /// The version of the app this chart installed
     pub app_version: String,
-    /// The char revision
+    /// The chart revision
     revision: String,
     /// Date/time when the chart was last updated
     updated: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,4 +398,30 @@ pub struct InstalledChart {
     pub name: String,
     /// The version of the app this chart installed
     pub app_version: String,
+    /// The char revision
+    revision: String,
+    /// Date/time when the chart was last updated
+    updated: String,
+    /// Status of the installed chart
+    status: String,
+    /// The ID of the chart that is installed
+    chart: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_get_installed_charts() {
+        const JSON_RESPONSE: &str = r#"[{"name":"test_chart","namespace":"default","revision":"50","updated":"2021-03-17 08:42:54.546347741 +0000 UTC","status":"deployed","chart":"test_chart-1.2.32-rc2","app_version":"1.2.32-rc2"}]"#;
+        let installed_charts: Vec<InstalledChart> =
+            serde_json::from_slice(JSON_RESPONSE.as_bytes()).expect("can not parse json");
+        assert_eq!(installed_charts.len(), 1);
+        let test_chart = installed_charts
+            .get(0)
+            .expect("can not grab the first result");
+        assert_eq!(test_chart.name, "test_chart");
+        assert_eq!(test_chart.chart, "test_chart-1.2.32-rc2");
+    }
 }


### PR DESCRIPTION
It would be very useful to have access to all the attributes returned by `helm list`. For a current project we need the additional information.

I've added a small test to validate that the returned json can be parsed.