### PR TITLE
Fix job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run:  make test-all
 
   done:
-    name: "Done!"
+    name: "Done"
     needs: [clippy, rustfmt, unit_test]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ok, right after merging the Bors config I immediately realized I used the wrong name for the done job (I used `Done!` instead of `Done`), so Bors will end up missing this status check, oops. This should fix it.